### PR TITLE
WHFB-130: Improve error and fix custom field type

### DIFF
--- a/Civi/Eventify/Hook/Post/EventifySync.php
+++ b/Civi/Eventify/Hook/Post/EventifySync.php
@@ -134,6 +134,10 @@ class EventifySync {
     try {
       $this->generatedToken = $this->generateToken($this->eventifyEventID);
 
+      if (is_null($this->generatedToken)) {
+        return;
+      }
+
       //When the participant is registered via Webform or online registration form
       //the custom fields will not passed if the fields are not created in a profile / forms
       //therefore, custom fields will not exist here so $syncStatus should be assigned as empty
@@ -330,7 +334,9 @@ class EventifySync {
 
     list($code, $response) = $this->callAPI($url, $header, $data);
     if (empty($response['session_token'])) {
-      throw new \Exception('Session token token does not exist');
+      $this->updateParticipantSyncStatus(400, $response);
+
+      return NULL;
     }
 
     return $response['session_token'];

--- a/Civi/Eventify/Hook/Post/EventifySync.php
+++ b/Civi/Eventify/Hook/Post/EventifySync.php
@@ -329,8 +329,6 @@ class EventifySync {
     ];
 
     list($code, $response) = $this->callAPI($url, $header, $data);
-    $this->handleIfApiReturnsError($code, $response);
-
     if (empty($response['session_token'])) {
       throw new \Exception('Session token token does not exist');
     }

--- a/xml/customFields_install.xml
+++ b/xml/customFields_install.xml
@@ -52,7 +52,7 @@
     <CustomField>
       <name>participant_roles_to_sync</name>
       <label>Participant roles to sync</label>
-      <data_type>Int</data_type>
+      <data_type>String</data_type>
       <html_type>Select</html_type>
       <is_required>0</is_required>
       <is_searchable>1</is_searchable>


### PR DESCRIPTION
## Overview

This PR changes the type participant roles custom field from int to string, so we could save the multiple roles and record the error when the token cannot be generated due to the credentials are not valid. 
