### PR TITLE
WHFB-130: Sync dynamic forms 

### DIFF
--- a/Civi/Eventify/Hook/AbstractEventifySync.php
+++ b/Civi/Eventify/Hook/AbstractEventifySync.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Civi\Eventify\Hook;
+
+use CRM_Eventify_SettingsManager as SettingsManager;
+
+abstract class AbstractEventifySync {
+
+  protected function getSettings() {
+    return SettingsManager::getSettingsValue();
+  }
+
+  /**
+   * @throws CiviCRM_API3_Exception
+   */
+  protected function callAPI($url, $header, $payload, $method = 'POST') {
+    set_time_limit(60);
+    $connection = curl_init();
+    switch ($method) {
+      case 'POST':
+        curl_setopt($connection, CURLOPT_POST, TRUE);
+        curl_setopt($connection, CURLOPT_POSTFIELDS, json_encode($payload));
+        break;
+
+      default:
+        curl_setopt($connection, CURLOPT_CUSTOMREQUEST, $method);
+        if (!is_null($payload)) {
+          curl_setopt($connection, CURLOPT_POSTFIELDS, json_encode($payload));
+        }
+    }
+    curl_setopt_array($connection, [
+      CURLOPT_URL            => $url,
+      CURLOPT_HTTPHEADER     => $header,
+      CURLOPT_RETURNTRANSFER => TRUE,
+      CURLOPT_TIMEOUT        => 30,
+    ]);
+
+    $response = curl_exec($connection);
+    $httpStatus = curl_getinfo($connection, CURLINFO_HTTP_CODE);
+    curl_close($connection);
+
+    return array_values([$httpStatus, json_decode($response, TRUE)]);
+  }
+
+}

--- a/Civi/Eventify/Hook/Custom/ParticipantCustomSync.php
+++ b/Civi/Eventify/Hook/Custom/ParticipantCustomSync.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Civi\Eventify\Hook\Custom;
+
+use Civi\Eventify\Hook\AbstractEventifySync;
+use CRM_Eventify_SettingsManager as SettingsManager;
+
+class ParticipantCustomSync extends AbstractEventifySync {
+
+  private $op;
+  private $groupID;
+  private $entityID;
+  private $params;
+
+  public function __construct($op, $groupID, $entityID, &$params) {
+    $this->op = $op;
+    $this->groupID = $groupID;
+    $this->entityID = $entityID;
+    $this->params = &$params;
+  }
+
+  public function sync() {
+    if (!$this->shouldSync()) {
+      return;
+    }
+
+    $cacheName = 'eventify_sync_params_' . $this->entityID;
+    $cache = \Civi::cache()->get($cacheName);
+    $detailsForm = $cache['details_form'];
+    $form = [];
+    foreach ($detailsForm as $key => $field) {
+      $form[$key]['id'] = $field['id'];
+      if ($field['id'] == 'country') {
+        $form[$key]['value'] = $this->getCountryByID($this->contact['country_id']);
+        continue;
+      }
+      if ($field['id'] == 'company') {
+        $form[$key]['value'] = $this->getOrganization();
+        continue;
+      }
+
+      if (!empty($field['max_length'])) {
+        $form[$key]['value'] = "";
+        continue;
+      }
+
+      $form[$key]['value'] = FALSE;
+    }
+
+    $settings = $this->getSettings();
+    $url = $settings[SettingsManager::API_URL] . '/attendee' . '/' . $cache['appuserid'];
+    $header = [
+      'Accept: application/json',
+      'Session-Token: ' . $cache['session_token'],
+      'Content-Type: application/json',
+    ];
+
+    $payload = [
+      'eventid' => $cache['eventid'],
+      'form_number' => $cache['form_number'],
+      'details_form' => $form,
+    ];
+
+    $this->callAPI($url, $header, $payload, 'PATCH');
+    \Civi::cache()->delete($cacheName);
+  }
+
+  private function shouldSync() {
+    // WHF specific group (participant details)
+    if ($this->groupID != 37) {
+      return FALSE;
+    }
+
+    return TRUE;
+  }
+
+  private function getCountryByID($id) {
+    if (empty($id)) {
+      $id = civicrm_api3('Setting', 'get', [
+        'sequential' => 1,
+        'return' => ["defaultContactCountry"],
+      ])['values'][0]['defaultContactCountry'];
+    }
+
+    return civicrm_api3('Country', 'get', [
+      'sequential' => 1,
+      'id' => $id,
+    ])['values'][0]['name'];
+  }
+
+  private function getOrganization() {
+    foreach ($this->params as $param) {
+      if ($param['column_name'] == 'organization_represented_247') {
+        return $param['value'];
+      }
+    }
+
+    return NULL;
+  }
+
+}

--- a/eventify.php
+++ b/eventify.php
@@ -141,3 +141,17 @@ function eventify_civicrm_post_callback($objectId) {
   $participantHook = new Civi\Eventify\Hook\Post\EventifySync($objectId);
   $participantHook->sync();
 }
+
+/**
+ * Implements hook_civicrm_custom().
+ *
+ * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_custom/
+ */
+function eventify_civicrm_custom($op, $groupID, $entityID, &$params) {
+  if ($op != 'create' && $op != 'edit') {
+    return;
+  }
+
+  $hook = new Civi\Eventify\Hook\Custom\ParticipantCustomSync($op, $groupID, $entityID, $params);
+  $hook->sync();
+}


### PR DESCRIPTION
## Overview

This PR syncs organization custom field and contact's country to Eventify dynamic form. 

## Before

Dynamic fields were not synced.

## After

Dynamic fields have been synced to Eventify. 

![screenshot-hub eventify io-2023 05 02-15_13_40](https://user-images.githubusercontent.com/208713/235697369-60a1ccca-e27e-437d-a6bf-acd0f566de0f.png)

## Technical Details

When CiviCRM post hook is called, only a participant object is created, but all custom fields submitted in the form do not exist. A custom post hook is added to sync the custom fields.  Since we want to sync all dynamic fields in one go to Eventify to reduce the latency, we are calling update an [attendee API]( https://adminapi.eventify.io/api/update-an-attendee/) to sync all fields in the Eventify dynamic form. In includes syncing non-custom fields, in this case, contact's country to Eventify 

Note: The dynamic form custom fields sync have been implemented to support WHF specific custom field and only work with the custom fields call participant details that a custom field name `organization_represented_247 `. 

